### PR TITLE
p-value initialization

### DIFF
--- a/genewordsearch/Classes.py
+++ b/genewordsearch/Classes.py
@@ -9,8 +9,8 @@ class WordFreq:
 	def __init__(self, word, freq):
 	# Constructor
 		self.word = word
-		self.p = 0
-		self.pCor = 0
+		self.p = None
+		self.pCor = None
 		self.freq = freq
 		self.total = 0
 		self.genes = []


### PR DESCRIPTION
Initializing p-values as zero could cause words for which p-values have not been calculated to have a significant p-value according to the program. Changed 0 to None for p-value and Bonferroni corrected p-value to avoid this issue.