### PR TITLE
Import top level modules in __init__.py

### DIFF
--- a/genewordsearch/__init__.py
+++ b/genewordsearch/__init__.py
@@ -1,0 +1,7 @@
+
+# TODO: import modules so they are available in the namespace and cand be used 
+#       when other modules in the namespace. e.g.
+#       > import geneWordSearch as gws
+#       > x = gws.geneWordSeach(['gene1','gene2','gene3'],'arabidopsis')
+
+from geneWordSearch import *


### PR DESCRIPTION
Importing these top level modules will expose them when you import the package.

I want to be able to access some functions via iPython:

```{python}
import geneWordSearch as gws
gws.geneWordSeach(...)
gws.geneWordBuilder(...)
```